### PR TITLE
add asynchronous autostart for recorder

### DIFF
--- a/araig_calculators/launch/test_folder_bagger.launch
+++ b/araig_calculators/launch/test_folder_bagger.launch
@@ -5,7 +5,7 @@
     <rosparam command="load" file="$(find turtlebot3_sim_tests)/config/test1_braking.yaml" />
     <param name="/calculators/dest_dir" value="$(arg dest_dir)" />
 
-    <node pkg="araig_calculators" type="folder_bagger_node" name="test_folder_bagger_node" output="screen" >
+    <node pkg="araig_calculators" type="folder_bagger_node" name="folder_bagger_node" output="screen" >
         <remap from="/start" to="/signal/runner/start_robot"/>
         <remap from="/stop" to="/signal/runner/test_completed"/>
         <remap from="/test_failed" to="/signal/runner/test_failed"/>

--- a/araig_test_runners/scripts/test_1_braking
+++ b/araig_test_runners/scripts/test_1_braking
@@ -11,7 +11,8 @@ self._input_interface = {
     "robot_has_stopped"    : "/signal/calc/robot_has_stopped",
     "start_test"           : "/signal/ui/start_test",
     "interrupt_test"       : "/signal/ui/interrupt_test",
-    "reset_test"           : "/signal/ui/reset_test"
+    "reset_test"           : "/signal/ui/reset_test",
+    "began_recording"      : "/signal/logger/begin_write"
 }
 # pub
 self._output_interface = {
@@ -30,7 +31,7 @@ class Test1(TestBase):
     def __init__(self, rate):
         
         extend_subscribers_dict = {
-            "robot_has_max_vel"  : "/signal/calc/robot_has_max_vel",
+            "robot_has_max_vel"  : "/signal/calc/robot_has_max_vel"
         }
         extend_publishers_dict = {
         }
@@ -47,8 +48,9 @@ class Test1(TestBase):
         rate = rate)
 
     def main(self):
-        # Standard startup, robot started on return
-        self.standardStartupSequence()
+        # Standard startup, robot started on return True, or recorder failed on return False
+        if not self.standardStartupSequence():
+            return
 
         # Sleep for some time to allow speed burst to settle
         if self.sleepUninterruptedFor(self.config_param['stabilization_timeout']) == self._RETURN_CASE_INTERRUPTED:

--- a/araig_test_runners/scripts/test_1_emergency
+++ b/araig_test_runners/scripts/test_1_emergency
@@ -10,7 +10,8 @@ self._input_interface = {
     "robot_has_stopped"    : "/signal/calc/robot_has_stopped",
     "start_test"           : "/signal/ui/start_test",
     "interrupt_test"       : "/signal/ui/interrupt_test",
-    "reset_test"           : "/signal/ui/reset_test"
+    "reset_test"           : "/signal/ui/reset_test",
+    "began_recording"      : "/signal/logger/begin_write"
 }
 # pub
 self._output_interface = {
@@ -45,8 +46,9 @@ class Test1(TestBase):
         rate = rate)
 
     def main(self):
-        # Standard startup, robot started on return
-        self.standardStartupSequence()
+        # Standard startup, robot started on return True, or recorder failed on return False
+        if not self.standardStartupSequence():
+            return
 
         # Wait for emergency signal. Prototype example of timed waiting.
         rospy.loginfo(rospy.get_name() + ": Waiting for emergency signal within {}s"

--- a/araig_test_runners/scripts/test_4
+++ b/araig_test_runners/scripts/test_4
@@ -10,7 +10,8 @@ self._input_interface = {
     "robot_has_stopped"    : "/signal/calc/robot_has_stopped",
     "start_test"           : "/signal/ui/start_test",
     "interrupt_test"       : "/signal/ui/interrupt_test",
-    "reset_test"           : "/signal/ui/reset_test"
+    "reset_test"           : "/signal/ui/reset_test",
+    "began_recording"      : "/signal/logger/begin_write"
 }
 # pub
 self._output_interface = {
@@ -43,8 +44,9 @@ class Test4(TestBase):
         rate = rate)
 
     def main(self):
-        # Standard startup, robot started on return
-        self.standardStartupSequence()
+        # Standard startup, robot started on return True, or recorder failed on return False
+        if not self.standardStartupSequence():
+            return
 
         # Wait until robot reaches goal
         result = self.timedLoopFallbackOnFlags([ "goal_and_stop"], self.config_param['goal_reach_timeout'])

--- a/araig_test_runners/scripts/test_5_with_nav
+++ b/araig_test_runners/scripts/test_5_with_nav
@@ -9,7 +9,8 @@ self._input_interface = {
     "robot_has_stopped"    : "/signal/calc/robot_has_stopped",
     "start_test"           : "/signal/ui/start_test",
     "interrupt_test"       : "/signal/ui/interrupt_test",
-    "reset_test"           : "/signal/ui/reset_test"
+    "reset_test"           : "/signal/ui/reset_test",
+    "began_recording"      : "/signal/logger/begin_write"
 }
 # pub
 self._output_interface = {
@@ -43,8 +44,9 @@ class Test5(TestBase):
         rate = rate)
 
     def main(self):
-        # Standard startup, robot started on return
-        self.standardStartupSequence()
+        # Standard startup, robot started on return True, or recorder failed on return False
+        if not self.standardStartupSequence():
+            return
 
         # Wait until robot reaches goal or collides
         result = self.timedLoopFallbackOnFlags([ "goal", "robot_in_collision"],

--- a/araig_test_runners/scripts/test_5_without_nav
+++ b/araig_test_runners/scripts/test_5_without_nav
@@ -10,7 +10,8 @@ self._input_interface = {
     "robot_has_stopped"    : "/signal/calc/robot_has_stopped",
     "start_test"           : "/signal/ui/start_test",
     "interrupt_test"       : "/signal/ui/interrupt_test",
-    "reset_test"           : "/signal/ui/reset_test"
+    "reset_test"           : "/signal/ui/reset_test",
+    "began_recording"      : "/signal/logger/begin_write"
 }
 # pub
 self._output_interface = {
@@ -45,8 +46,9 @@ class Test5NoNav(TestBase):
         rate = rate)
 
     def main(self):
-        # Standard startup, robot started on return
-        self.standardStartupSequence()
+        # Standard startup, robot started on return True, or recorder failed on return False
+        if not self.standardStartupSequence():
+            return
 
         # Sleep a short duration to allow robot to start moving, in order not to get premature robot stopped signal
         rospy.loginfo(rospy.get_name() + ": Sleeping {}s for robo to start moving"


### PR DESCRIPTION
Recorder publishes a signal when it starts recording, and runners wait asynchronously for this signal with a timeout, instead of a fixed waiting time.