### PR TITLE
fix reset mechanism for param logger

### DIFF
--- a/araig_calculators/src/loggers/rosparam_logger.py
+++ b/araig_calculators/src/loggers/rosparam_logger.py
@@ -47,8 +47,12 @@ class RosparamLoggerClass(BaseLogger):
                     rospy.sleep(self.config_param[self.node_name + "/stop_offset"])
                     self.killCommandProc()
 
-        # Wait for stop signal
-        while stop is False and start is True and not rospy.is_shutdown():
+        rospy.loginfo(
+            rospy.get_name() +
+            ": Waiting for trigger signals to reset")
+        # Wait for stop and start to go low
+        while (stop or start) and not rospy.is_shutdown():
             self._rate.sleep()
             stop = self.getSafeFlag("stop")
             start = self.getSafeFlag("start")
+        rospy.loginfo(rospy.get_name() + ": Resetting.")

--- a/araig_calculators/tests/node_tests/test_rosparam_logger_node.test
+++ b/araig_calculators/tests/node_tests/test_rosparam_logger_node.test
@@ -5,7 +5,7 @@
     <rosparam command="load" file="$(find turtlebot3_sim_tests)/config/test1_braking.yaml" />
     <param name="/calculators/dest_dir" value="$(arg dest_dir)" />
 
-    <node pkg="araig_calculators" type="rosparam_logger_node" name="rosparam_logger_node" output="screen">
+    <node pkg="araig_calculators" type="rosparam_logger_node" name="param_logger_node" output="screen">
         <remap from="/start" to="/test/start"/>
         <remap from="/stop" to="/test/stop"/>
     </node>


### PR DESCRIPTION
param logger had an issue where it was stuck in toggling when interrupted