### PR TITLE
fix logic changed by autopep8

### DIFF
--- a/araig_calculators/src/difference/diff_pose_temporal.py
+++ b/araig_calculators/src/difference/diff_pose_temporal.py
@@ -85,7 +85,7 @@ class diffPoseTemporal(BaseCalculator):
         if temp[self._sub_topic_stop] is not None and \
                 temp[self._sub_topic_start] is not None and \
                 temp[self._sub_topic_start].data:
-            if self._prestate_stop is True and \
+            if self._prestate_stop is False and \
                     temp[self._sub_topic_stop].data is True:
                 self._posestamp_stop = temp[self._sub_topic_pose]
                 rospy.loginfo(rospy.get_name() + ": Stopped")

--- a/araig_calculators/src/loggers/folder_bagger.py
+++ b/araig_calculators/src/loggers/folder_bagger.py
@@ -99,7 +99,7 @@ class FolderBagger(BaseLogger):
             start = self.getSafeFlag("start")
 
         # Create folder -> sleep -> start recording
-        if start and stop is False:
+        if start is True and stop is False:
             now = datetime.now()
             dt_string = now.strftime("%d_%m_%Y_%H_%M_%S")
 

--- a/araig_calculators/src/loggers/rosparam_logger.py
+++ b/araig_calculators/src/loggers/rosparam_logger.py
@@ -34,7 +34,7 @@ class RosparamLoggerClass(BaseLogger):
             self._rate.sleep()
             start = self.getSafeFlag("start")
 
-        if start and stop is False:
+        if start is True and stop is False:
             # Wait for folder to be created before starting
             rospy.loginfo(rospy.get_name() + ": Start received. Sleep {}s to prepare..."
                           .format(self.config_param[self.node_name + "/start_offset"]))


### PR DESCRIPTION
This issue created from https://github.com/ipa320/araig_test_stack/pull/58 7b40c1a6c15bb7d5823205e0d8c77e0f3dd44735
Be careful when run `autopep8 --in-place --aggressive --aggressive --aggressive files"
as https://github.com/hhatto/autopep8 mentioned,  **one " --aggressive" enable non-whitespace changes; multiple -a result"--aggressive" result in more aggressive changes**